### PR TITLE
Update to 0.15.4

### DIFF
--- a/0.15/Dockerfile
+++ b/0.15/Dockerfile
@@ -3,8 +3,8 @@ FROM frolvlad/alpine-glibc:alpine-3.5
 MAINTAINER https://github.com/dtandersen/docker_factorio_server
 
 ENV PORT=34197 \
-    VERSION=0.15.3 \
-    SHA1=5b6b8c150c9f25a5c4ed470cdd732753ab7ad67e
+    VERSION=0.15.4 \
+    SHA1=7308abe22b665495505303d54490c0d7e37afaed
 
 RUN mkdir /opt && \
     apk add --update --no-cache tini pwgen && \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Factorio [![](https://images.microbadger.com/badges/image/dtandersen/factorio.svg)](https://microbadger.com/images/dtandersen/factorio "Get your own image badge on microbadger.com") [![Docker Pulls](https://img.shields.io/docker/pulls/dtandersen/factorio.svg)](https://hub.docker.com/r/dtandersen/factorio/) [![Docker Stars](https://img.shields.io/docker/stars/dtandersen/factorio.svg)](https://hub.docker.com/r/dtandersen/factorio/)
 
-* `0.15.3`, `0.15`, `latest` [(0.15/Dockerfile)](https://github.com/dtandersen/docker_factorio_server/blob/master/0.15/Dockerfile)
+* `0.15.4`, `0.15`, `latest` [(0.15/Dockerfile)](https://github.com/dtandersen/docker_factorio_server/blob/master/0.15/Dockerfile)
 * `0.14.23`, `0.14`, `stable` [(0.14/Dockerfile)](https://github.com/dtandersen/docker_factorio_server/blob/master/0.14/Dockerfile)
 * `0.13.20`, `0.13`  [(0.13/Dockerfile)](https://github.com/dtandersen/docker_factorio_server/blob/master/0.13/Dockerfile)
 


### PR DESCRIPTION
Bumped the version number in the `Dockerfile` and README, and updated the SHA1, hopefully that's all that's needed for a version bump.