### PR TITLE
Add map-settings.json config file

### DIFF
--- a/0.15/docker-entrypoint.sh
+++ b/0.15/docker-entrypoint.sh
@@ -21,10 +21,15 @@ if [ ! -f $CONFIG/map-gen-settings.json ]; then
   cp /opt/factorio/data/map-gen-settings.example.json $CONFIG/map-gen-settings.json
 fi
 
+if [ ! -f $CONFIG/map-settings.json ]; then
+  cp /opt/factorio/data/map-settings.example.json $CONFIG/map-settings.json
+fi
+
 if ! find -L $SAVES -iname \*.zip -mindepth 1 -print | grep -q .; then
   /opt/factorio/bin/x64/factorio \
     --create $SAVES/_autosave1.zip  \
-    --map-gen-settings $CONFIG/map-gen-settings.json
+    --map-gen-settings $CONFIG/map-gen-settings.json \
+    --map-settings $CONFIG/map-settings.json
 fi
 
 exec /opt/factorio/bin/x64/factorio \

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Now run the server as before. In about a minute the new version of Factorio shou
 
 ## Saves
 
-A new map named `_autosave1.zip` is generated the first time the server is started. The `map-gen-settings.json` file in `/tmp/factorio/config` is used for the map settings. On subsequent runs the newest save is used.
+A new map named `_autosave1.zip` is generated the first time the server is started. The `map-gen-settings.json` and `map-settings.json` files in `/tmp/factorio/config` are used for the map settings. On subsequent runs the newest save is used.
 
 To load an old save stop the server and run the command `touch oldsave.zip`. This resets the date. Then restart the server. Another option is to delete all saves except one.
 


### PR DESCRIPTION
Version 0.15 added a bunch of new map settings in a third configuration file.  Now you can control the evolution rate, biter expansion, pollution spread, and more.