### PR TITLE
Allow to define RCON port as well

### DIFF
--- a/0.15/Dockerfile
+++ b/0.15/Dockerfile
@@ -3,6 +3,7 @@ FROM frolvlad/alpine-glibc:alpine-3.6
 MAINTAINER https://github.com/dtandersen/docker_factorio_server
 
 ENV PORT=34197 \
+    RCON_PORT=27015 \
     VERSION=0.15.37 \
     SHA1=f2a05ee3c0cbe1d7fe5f8928a337b7133aaa70fc
 
@@ -20,7 +21,7 @@ RUN mkdir /opt && \
 
 VOLUME /factorio
 
-EXPOSE $PORT/udp 27015/tcp
+EXPOSE $PORT/udp $RCON_PORT/tcp
 
 COPY ./docker-entrypoint.sh /
 

--- a/0.15/docker-entrypoint.sh
+++ b/0.15/docker-entrypoint.sh
@@ -38,6 +38,6 @@ exec /opt/factorio/bin/x64/factorio \
   --server-settings $CONFIG/server-settings.json \
   --server-whitelist $CONFIG/server-whitelist.json \
   --server-banlist $CONFIG/server-banlist.json \
-  --rcon-port 27015 \
+  --rcon-port $RCON_PORT \
   --rcon-password "$(cat $CONFIG/rconpw)" \
   --server-id /factorio/config/server-id.json


### PR DESCRIPTION
I stumbled over this when I tried to run multiple servers with "network_mode: host", which I need so they show up in the LAN browser.