### PR TITLE
Allowing non-root user to run factorio

### DIFF
--- a/0.15/Dockerfile
+++ b/0.15/Dockerfile
@@ -14,6 +14,7 @@ RUN mkdir /opt && \
         -o /tmp/factorio_headless_x64_$VERSION.tar.xz && \
     echo "$SHA1  /tmp/factorio_headless_x64_$VERSION.tar.xz" | sha1sum -c && \
     tar xf /tmp/factorio_headless_x64_$VERSION.tar.xz --directory /opt && \
+    chmod -R ugo=rwx /opt/factorio && \
     rm /tmp/factorio_headless_x64_$VERSION.tar.xz && \
     ln -s /factorio/saves /opt/factorio/saves && \
     ln -s /factorio/mods /opt/factorio/mods && \
@@ -24,6 +25,7 @@ VOLUME /factorio
 EXPOSE $PORT/udp $RCON_PORT/tcp
 
 COPY ./docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
 
 ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["/docker-entrypoint.sh"]


### PR DESCRIPTION
When starting the container with `docker run -d -u $(id -u factorio):$(id -g factorio) ...`, permission is denied upon trying to create `/opt/factorio/.lock` file.
This permission tweak will allow caller to pass desired user from host to container such that the permissions are retained correctly when games are saved to the mount.

Also, it just feels wrong to run factorio as root, container or not.  :)