### PR TITLE
Fix volume permissions for docker-compose

### DIFF
--- a/0.16/Dockerfile
+++ b/0.16/Dockerfile
@@ -12,9 +12,7 @@ ENV PORT=34197 \
     VERSION=0.16.7 \
     SHA1=7bd14a4d8abe2feef015d1b3d75c6ec82a5e2ccf
 
-VOLUME /factorio
-
-RUN mkdir -p /opt && \
+RUN mkdir -p /opt /factorio && \
     apk add --update --no-cache pwgen && \
     apk add --update --no-cache --virtual .build-deps curl && \
     curl -sSL https://www.factorio.com/get-download/$VERSION/headless/linux64 \
@@ -29,6 +27,8 @@ RUN mkdir -p /opt && \
     addgroup -g $PGID -S $GROUP && \
     adduser -u $PUID -G $USER -s /bin/sh -SDH $GROUP && \
     chown -R $USER:$GROUP /opt/factorio /factorio
+
+VOLUME /factorio
 
 EXPOSE $PORT/udp $RCON_PORT/tcp
 


### PR DESCRIPTION
When using named containers in docker compose, it creates them with root and the factorio docker container fails to start because it doesn't have write permissions. Reproduce by using the following docker-compose file:

    version: '3.2'
    services:
      server:
        image: dtandersen/factorio:0.16.7
        volumes:
        - logs:/var/log
        - data:/factorio
        ports:
        - "34197:34197/udp"
        - "27015:27015/tcp"
    volumes:
      logs:
      data:

With this proposed change, the /factorio folder is created *before* it is made a volume. This causes docker to correctly preserve the permissions, the docker-compose file above works now.

This is related to https://github.com/dtandersen/docker_factorio_server/issues/91 and maybe also makes https://github.com/dtandersen/docker_factorio_server/pull/99 obsolete.