### PR TITLE
Expose script-output to mounted volume

### DIFF
--- a/0.16/Dockerfile
+++ b/0.16/Dockerfile
@@ -14,7 +14,8 @@ ENV PORT=34197 \
     SAVES=/factorio/saves \
     CONFIG=/factorio/config \
     MODS=/factorio/mods \
-    SCENARIOS=/factorio/scenarios
+    SCENARIOS=/factorio/scenarios \
+    SCRIPTOUTPUT=/factorio/script-output
 
 RUN mkdir -p /opt /factorio && \
     apk add --update --no-cache pwgen && \
@@ -28,6 +29,7 @@ RUN mkdir -p /opt /factorio && \
     ln -s $SAVES /opt/factorio/saves && \
     ln -s $MODS /opt/factorio/mods && \
     ln -s $SCENARIOS /opt/factorio/scenarios && \
+    ln -s $SCRIPTOUTPUT /opt/factorio/script-output && \
     apk del .build-deps && \
     addgroup -g $PGID -S $GROUP && \
     adduser -u $PUID -G $GROUP -s /bin/sh -SDH $USER && \

--- a/0.16/files/docker-entrypoint.sh
+++ b/0.16/files/docker-entrypoint.sh
@@ -8,6 +8,7 @@ mkdir -p $SAVES
 mkdir -p $CONFIG
 mkdir -p $MODS
 mkdir -p $SCENARIOS
+mkdir -p $SCRIPTOUTPUT
 
 if [ ! -f $CONFIG/rconpw ]; then
   echo $(pwgen 15 1) > $CONFIG/rconpw


### PR DESCRIPTION
some mods write to script-output via `game.write_file()`.  this folder is currently hidden inside the container since it isn't explicitly linked to the folder which is setup as mounted volume.

this change makes the script-output folder accessible on the host system