### PR TITLE
Adding support for 0.17's new banlist and adminlist options

### DIFF
--- a/0.17/files/docker-entrypoint.sh
+++ b/0.17/files/docker-entrypoint.sh
@@ -52,6 +52,7 @@ exec su-exec factorio /opt/factorio/bin/x64/factorio \
   --server-whitelist $CONFIG/server-whitelist.json \
   --use-server-whitelist \
   --server-adminlist $CONFIG/server-adminlist.json \
+  --server-banlist $CONFIG/server-banlist.json \
   --rcon-password "$(cat $CONFIG/rconpw)" \
   --server-id /factorio/config/server-id.json \
   $@

--- a/0.17/files/docker-entrypoint.sh
+++ b/0.17/files/docker-entrypoint.sh
@@ -51,6 +51,7 @@ exec su-exec factorio /opt/factorio/bin/x64/factorio \
   --rcon-port $RCON_PORT \
   --server-whitelist $CONFIG/server-whitelist.json \
   --use-server-whitelist \
+  --server-adminlist $CONFIG/server-adminlist.json \
   --rcon-password "$(cat $CONFIG/rconpw)" \
   --server-id /factorio/config/server-id.json \
   $@

--- a/README.md
+++ b/README.md
@@ -164,6 +164,15 @@ Create file `config/server-whitelist.json` and add the whitelisted users.
 		"friend"
 	]
 
+## Adminlisting (0.17.1+)
+
+Create file `config/server-adminlist.json` and add the adminlisted users.
+
+    [
+        "you",
+        "friend"
+    ]
+
 # Container Details
 
 The philosophy is to [keep it simple](http://wiki.c2.com/?KeepItSimple).
@@ -182,7 +191,8 @@ To keep things simple, the container uses a single volume mounted at `/factorio`
     |   |-- map-gen-settings.json
     |   |-- rconpw
     |   |-- server-settings.json
-    |   `-- server-whitelist.json
+    |   |-- server-whitelist.json
+    |   `-- server-adminlist.json
     |-- mods
     |   `-- fancymod.zip
     `-- saves

--- a/README.md
+++ b/README.md
@@ -164,6 +164,15 @@ Create file `config/server-whitelist.json` and add the whitelisted users.
 		"friend"
 	]
 
+## Banlisting (0.17.1+)
+
+Create file `config/server-banlist.json` and add the banlisted users.
+
+    [
+        "bad_person",
+        "other_bad_person"
+    ]
+
 ## Adminlisting (0.17.1+)
 
 Create file `config/server-adminlist.json` and add the adminlisted users.
@@ -192,6 +201,7 @@ To keep things simple, the container uses a single volume mounted at `/factorio`
     |   |-- rconpw
     |   |-- server-settings.json
     |   |-- server-whitelist.json
+    |   |-- server-banlist.json
     |   `-- server-adminlist.json
     |-- mods
     |   `-- fancymod.zip


### PR DESCRIPTION
The `admins` configuration in server-settings.json doesn't do anything anymore, and has been replaced by adminlist. Additionally, banlist is the new way to handle bans. This adds support for these features.