### PR TITLE
User Permission Errors

### DIFF
--- a/0.17/Dockerfile
+++ b/0.17/Dockerfile
@@ -41,4 +41,6 @@ EXPOSE $PORT/udp $RCON_PORT/tcp
 
 COPY files/ /
 
+USER $USER
+
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/0.17/files/docker-entrypoint.sh
+++ b/0.17/files/docker-entrypoint.sh
@@ -43,7 +43,7 @@ if [ "$(id -u)" = '0' ]; then
   chown -R factorio:factorio $FACTORIO_VOL
 fi
 
-exec su-exec factorio /opt/factorio/bin/x64/factorio \
+exec /opt/factorio/bin/x64/factorio \
   --port $PORT \
   --start-server-load-latest \
   --server-settings $CONFIG/server-settings.json \


### PR DESCRIPTION
Added the USER command to the dockerfile to set the user that the entrypoint script is run under and removed the su-exec command for setting the user to run the server under.

This fixes the permission error with the latest update and allows the command to be run by the user set in the $USER variable of the docker file