### PR TITLE
#197: revert external injection of server-settings.json and include e…

### DIFF
--- a/0.17/Dockerfile
+++ b/0.17/Dockerfile
@@ -18,7 +18,7 @@ ENV PORT=34197 \
     SCRIPTOUTPUT=/factorio/script-output
 
 RUN mkdir -p /opt /factorio && \
-    apk add --update --no-cache pwgen su-exec binutils && \
+    apk add --update --no-cache pwgen su-exec binutils gettext libintl && \
     apk add --update --no-cache --virtual .build-deps curl && \
     curl -sSL https://www.factorio.com/get-download/$VERSION/headless/linux64 \
         -o /tmp/factorio_headless_x64_$VERSION.tar.xz && \

--- a/0.17/Dockerfile
+++ b/0.17/Dockerfile
@@ -15,7 +15,8 @@ ENV PORT=34197 \
     CONFIG=/factorio/config \
     MODS=/factorio/mods \
     SCENARIOS=/factorio/scenarios \
-    SCRIPTOUTPUT=/factorio/script-output
+    SCRIPTOUTPUT=/factorio/script-output \
+    MAX_PLAYERS=0
 
 RUN mkdir -p /opt /factorio && \
     apk add --update --no-cache pwgen su-exec binutils gettext libintl && \

--- a/0.17/files/docker-entrypoint.sh
+++ b/0.17/files/docker-entrypoint.sh
@@ -12,13 +12,23 @@ mkdir -p $SCENARIOS
 mkdir -p $SCRIPTOUTPUT
 
 if [ ! -f $CONFIG/rconpw ]; then
-  # Generate a new RCON password if none exists
-  echo $(pwgen 15 1) > $CONFIG/rconpw
+  if [[ -z "$RCON_PASSWORD" ]]; then
+    # Generate a new RCON password if none exists
+    echo $(pwgen 15 1) > $CONFIG/rconpw
+  else
+    echo $RCON_PASSWORD > $CONFIG/rconpw
+  fi
 fi
 
 if [ ! -f $CONFIG/server-settings.json ]; then
-  # Copy default settings if server-settings.json doesn't exist
-  cp /opt/factorio/data/server-settings.example.json $CONFIG/server-settings.json
+  # If the INSTANCE_NAME environment variable is set, we assume, that we can provision the settings from the other variables
+  if [[ -z "$INSTANCE_NAME" ]]; then
+    # Copy default settings if server-settings.json doesn't exist
+    cp /opt/factorio/data/server-settings.example.json $CONFIG/server-settings.json
+  else
+    echo "provisioning server-settings.json from env variables"
+    envsubst < /server-settings.json > $CONFIG/server-settings.json
+  fi
 fi
 
 if [ ! -f $CONFIG/map-gen-settings.json ]; then

--- a/0.17/files/docker-entrypoint.sh
+++ b/0.17/files/docker-entrypoint.sh
@@ -27,7 +27,7 @@ if [ ! -f $CONFIG/server-settings.json ]; then
       # Copy default settings if server-settings.json doesn't exist
       cp /opt/factorio/data/server-settings.example.json $CONFIG/server-settings.json
     else
-      cp /config/server-settings.json $CONFIG/server-settings.json
+      envsubst < /config/server-settings.json > $CONFIG/server-settings.json
     fi
   else
     echo "provisioning server-settings.json from env variables"

--- a/0.17/files/server-settings.json
+++ b/0.17/files/server-settings.json
@@ -1,0 +1,63 @@
+{
+  "name": "${INSTANCE_NAME}",
+  "description": "${INSTANCE_DESC}",
+  "tags": ["game", "tags"],
+
+  "_comment_max_players": "Maximum number of players allowed, admins can join even a full server. 0 means unlimited.",
+  "max_players": 0,
+
+  "_comment_visibility": ["public: Game will be published on the official Factorio matching server",
+                          "lan: Game will be broadcast on LAN"],
+  "visibility":
+  {
+    "public": true,
+    "lan": true
+  },
+
+  "_comment_credentials": "Your factorio.com login credentials. Required for games with visibility public",
+  "username": "${FACTORIO_USER}",
+  "password": "",
+
+  "_comment_token": "Authentication token. May be used instead of 'password' above.",
+  "token": "${FACTORIO_TOKEN}",
+
+  "game_password": "${GAME_PASSWORD}",
+
+  "_comment_require_user_verification": "When set to true, the server will only allow clients that have a valid Factorio.com account",
+  "require_user_verification": true,
+
+  "_comment_max_upload_in_kilobytes_per_second" : "optional, default value is 0. 0 means unlimited.",
+  "max_upload_in_kilobytes_per_second": 0,
+
+  "_comment_minimum_latency_in_ticks": "optional one tick is 16ms in default speed, default value is 0. 0 means no minimum.",
+  "minimum_latency_in_ticks": 0,
+
+  "_comment_ignore_player_limit_for_returning_players": "Players that played on this map already can join even when the max player limit was reached.",
+  "ignore_player_limit_for_returning_players": false,
+
+  "_comment_allow_commands": "possible values are, true, false and admins-only",
+  "allow_commands": "admins-only",
+
+  "_comment_autosave_interval": "Autosave interval in minutes",
+  "autosave_interval": 10,
+
+  "_comment_autosave_slots": "server autosave slots, it is cycled through when the server autosaves.",
+  "autosave_slots": 5,
+
+  "_comment_afk_autokick_interval": "How many minutes until someone is kicked when doing nothing, 0 for never.",
+  "afk_autokick_interval": 0,
+
+  "_comment_auto_pause": "Whether should the server be paused when no players are present.",
+  "auto_pause": true,
+
+  "only_admins_can_pause_the_game": true,
+
+  "_comment_autosave_only_on_server": "Whether autosaves should be saved only on server or also on all connected clients. Default is true.",
+  "autosave_only_on_server": true,
+  
+  "_comment_non_blocking_saving": "Highly experimental feature, enable only at your own risk of losing your saves. On UNIX systems, server will fork itself to create an autosave. Autosaving on connected Windows clients will be disabled regardless of autosave_only_on_server option.",
+  "non_blocking_saving": false,
+
+  "_comment_admins": "List of case insensitive usernames, that will be promoted immediately",
+  "admins": []
+}

--- a/0.17/files/server-settings.json
+++ b/0.17/files/server-settings.json
@@ -4,7 +4,7 @@
   "tags": ["game", "tags"],
 
   "_comment_max_players": "Maximum number of players allowed, admins can join even a full server. 0 means unlimited.",
-  "max_players": 0,
+  "max_players": ${MAX_PLAYERS},
 
   "_comment_visibility": ["public: Game will be published on the official Factorio matching server",
                           "lan: Game will be broadcast on LAN"],

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Create file `config/server-adminlist.json` and add the adminlisted users.
         "friend"
     ]
 
-## Customize configuration files
+## Customize configuration files (0.17.x+)
 
 Out-of-the box, factorio does not support environment variables inside the configuration files. A workaround is the usage of `envsubst` which generates the configuration files dynamically during startup from environment variables set in docker-compose:
 
@@ -199,7 +199,7 @@ Example which replaces the server-settings.json:
 	  environment:
 	    - INSTANCE_NAME=Your Instance's Name
 	    - INSTANCE_DESC=Your Instance's Description
-	  entrypoint: /bin/sh -c "envsubst < /server-settings.json > /factorio/config/server-settings.json && exec /docker-entrypoint.sh"
+	  entrypoint: /bin/sh -c "mkdir -p /factorio/config && envsubst < /server-settings.json > /factorio/config/server-settings.json && exec /docker-entrypoint.sh"
 
 The `server-settings.json` file may then contain the variable references like this:
 

--- a/README.md
+++ b/README.md
@@ -184,9 +184,9 @@ Create file `config/server-adminlist.json` and add the adminlisted users.
 
 ## Customize configuration files
 
-Out-of-the box, factorio does not support environment variables inside the configuration files. A workaround is the usage of `envsubst` which generates the configuration files dynamically during startup.
+Out-of-the box, factorio does not support environment variables inside the configuration files. A workaround is the usage of `envsubst` which generates the configuration files dynamically during startup from environment variables set in docker-compose:
 
-Example for server-settings.json:
+Example which replaces the server-settings.json:
 
 
 	factorio_1:

--- a/README.md
+++ b/README.md
@@ -182,6 +182,31 @@ Create file `config/server-adminlist.json` and add the adminlisted users.
         "friend"
     ]
 
+## Customize configuration files
+
+Out-of-the box, factorio does not support environment variables inside the configuration files. A workaround is the usage of `envsubst` which generates the configuration files dynamically during startup.
+
+Example for server-settings.json:
+
+
+	factorio_1:
+	  image: dtanders/factorio
+	  ports:
+	    - "34197:34197/udp"
+	  volumes:
+	   - /opt/factorio:/factorio
+	   - ./server-settings.json:/server-settings.json
+	  environment:
+	    - INSTANCE_NAME=Your Instance's Name
+	    - INSTANCE_DESC=Your Instance's Description
+	  entrypoint: /bin/sh -c "envsubst < /server-settings.json > /factorio/config/server-settings.json && exec /docker-entrypoint.sh"
+
+The `server-settings.json` file may then contain the variable references like this:
+
+	"name": "${INSTANCE_NAME}",
+	"description": "${INSTANCE_DESC}",
+
+
 # Container Details
 
 The philosophy is to [keep it simple](http://wiki.c2.com/?KeepItSimple).

--- a/README.md
+++ b/README.md
@@ -182,30 +182,17 @@ Create file `config/server-adminlist.json` and add the adminlisted users.
         "friend"
     ]
 
-## Customize configuration files (0.17.x+)
+# Provisioning 
 
-Out-of-the box, factorio does not support environment variables inside the configuration files. A workaround is the usage of `envsubst` which generates the configuration files dynamically during startup from environment variables set in docker-compose:
+## server-settings.json
 
-Example which replaces the server-settings.json:
+The following environment variables can be set to provision the server-settings.json with the given configuration:
 
-
-	factorio_1:
-	  image: dtanders/factorio
-	  ports:
-	    - "34197:34197/udp"
-	  volumes:
-	   - /opt/factorio:/factorio
-	   - ./server-settings.json:/server-settings.json
-	  environment:
-	    - INSTANCE_NAME=Your Instance's Name
-	    - INSTANCE_DESC=Your Instance's Description
-	  entrypoint: /bin/sh -c "mkdir -p /factorio/config && envsubst < /server-settings.json > /factorio/config/server-settings.json && exec /docker-entrypoint.sh"
-
-The `server-settings.json` file may then contain the variable references like this:
-
-	"name": "${INSTANCE_NAME}",
-	"description": "${INSTANCE_DESC}",
-
+* `INSTANCE_NAME` - Name of the instance
+* `INSTANCE_DESC` - Description of the instance
+* `FACTORIO_USER` - factorio.com username
+* `FACTORIO_TOKEN` - factorio.com token
+* `GAME_PASSWORD` - Game password (optional)
 
 # Container Details
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ The following environment variables can be set to provision the server-settings.
 * `FACTORIO_USER` - factorio.com username
 * `FACTORIO_TOKEN` - factorio.com token
 * `GAME_PASSWORD` - Game password (optional)
+# `MAX_PLAYERS` - Number of max players, defaults to 0 (unlimited)
 
 # Container Details
 


### PR DESCRIPTION
I reverted the last changes and included the server-settings.json template into the original image. 
This allows minor changes in the entrypoint so that the docker-compose file now is really clean. 
````
 factorio_0.17.5:
    image: factorio
    ports:
     - "34199:34199/udp"
    volumes:
     - /opt/factorio/instance3:/factorio
    environment:
      - PORT=34199
      - RCON_PORT=34202
      - RCON_PASSWORD=foobar
      - INSTANCE_NAME=fooooo
      - INSTANCE_DESC=some bar text
      - FACTORIO_USER=lorem
      - FACTORIO_TOKEN=ipsum
```` 