### PR TITLE
#197: Externalize config creation

### DIFF
--- a/0.17/Dockerfile
+++ b/0.17/Dockerfile
@@ -13,6 +13,7 @@ ENV PORT=34197 \
     SHA1=b12e3882da950450fd5225c82b0790a1f4418946 \
     SAVES=/factorio/saves \
     CONFIG=/factorio/config \
+    PROVISION=/provisioning \
     MODS=/factorio/mods \
     SCENARIOS=/factorio/scenarios \
     SCRIPTOUTPUT=/factorio/script-output

--- a/0.17/files/docker-entrypoint.sh
+++ b/0.17/files/docker-entrypoint.sh
@@ -1,48 +1,7 @@
 #!/bin/sh -x
 set -e
 
-id
-
-FACTORIO_VOL=/factorio
-mkdir -p $FACTORIO_VOL
-mkdir -p $SAVES
-mkdir -p $CONFIG
-mkdir -p $MODS
-mkdir -p $SCENARIOS
-mkdir -p $SCRIPTOUTPUT
-
-if [ ! -f $CONFIG/rconpw ]; then
-  # Generate a new RCON password if none exists
-  echo $(pwgen 15 1) > $CONFIG/rconpw
-fi
-
-if [ ! -f $CONFIG/server-settings.json ]; then
-  # Copy default settings if server-settings.json doesn't exist
-  cp /opt/factorio/data/server-settings.example.json $CONFIG/server-settings.json
-fi
-
-if [ ! -f $CONFIG/map-gen-settings.json ]; then
-  cp /opt/factorio/data/map-gen-settings.example.json $CONFIG/map-gen-settings.json
-fi
-
-if [ ! -f $CONFIG/map-settings.json ]; then
-  cp /opt/factorio/data/map-settings.example.json $CONFIG/map-settings.json
-fi
-
-if find -L $SAVES -iname \*.tmp.zip -mindepth 1 -print | grep -q .; then
-  # Delete incomplete saves (such as after a forced exit)
-  rm -f $SAVES/*.tmp.zip
-fi
-
-if [ "$(id -u)" = '0' ]; then
-  # Take ownership of factorio data if running as root
-  chown -R factorio:factorio $FACTORIO_VOL
-  # Make sure we own temp
-  #mkdir -p /opt/factorio/temp
-  #chown -R factorio:factorio /opt/factorio/temp
-  # Drop to the factorio user
-  SU_EXEC="su-exec factorio"
-fi
+sh /initConfig.sh
 
 if ! find -L $SAVES -iname \*.zip -mindepth 1 -print | grep -q .; then
   # Generate a new map if no save ZIPs exist
@@ -52,15 +11,4 @@ if ! find -L $SAVES -iname \*.zip -mindepth 1 -print | grep -q .; then
     --map-settings $CONFIG/map-settings.json
 fi
 
-exec ${SU_EXEC} /opt/factorio/bin/x64/factorio \
-  --port $PORT \
-  --start-server-load-latest \
-  --server-settings $CONFIG/server-settings.json \
-  --server-banlist $CONFIG/server-banlist.json \
-  --rcon-port $RCON_PORT \
-  --server-whitelist $CONFIG/server-whitelist.json \
-  --use-server-whitelist \
-  --server-adminlist $CONFIG/server-adminlist.json \
-  --rcon-password "$(cat $CONFIG/rconpw)" \
-  --server-id /factorio/config/server-id.json \
-  "$@"
+sh /startFactorio.sh start-server-load-latest

--- a/0.17/files/initConfig.sh
+++ b/0.17/files/initConfig.sh
@@ -1,0 +1,53 @@
+#!/bin/sh -x
+set -e
+
+id
+
+FACTORIO_VOL=/factorio
+mkdir -p $FACTORIO_VOL
+mkdir -p $SAVES
+mkdir -p $CONFIG
+mkdir -p $MODS
+mkdir -p $SCENARIOS
+mkdir -p $SCRIPTOUTPUT
+
+echo "initializing config"
+
+# If there is a /customConfig directory, copy over all stuff from there first
+if [ -d $PROVISION ]; then
+  echo "custom provisioning data provided, coping over"
+  cp -r $PROVISION/* $FACTORIO_VOL 
+fi
+
+if [ ! -f $CONFIG/rconpw ]; then
+  # Generate a new RCON password if none exists
+  echo $(pwgen 15 1) > $CONFIG/rconpw
+fi
+
+if [ ! -f $CONFIG/server-settings.json ]; then
+  # Copy default settings if server-settings.json doesn't exist
+  cp /opt/factorio/data/server-settings.example.json $CONFIG/server-settings.json
+fi
+
+if [ ! -f $CONFIG/map-gen-settings.json ]; then
+  cp /opt/factorio/data/map-gen-settings.example.json $CONFIG/map-gen-settings.json
+fi
+
+if [ ! -f $CONFIG/map-settings.json ]; then
+  cp /opt/factorio/data/map-settings.example.json $CONFIG/map-settings.json
+fi
+
+if find -L $SAVES -iname \*.tmp.zip -mindepth 1 -print | grep -q .; then
+  # Delete incomplete saves (such as after a forced exit)
+  rm -f $SAVES/*.tmp.zip
+fi
+
+if [ "$(id -u)" = '0' ]; then
+  # Take ownership of factorio data if running as root
+  chown -R factorio:factorio $FACTORIO_VOL
+  # Make sure we own temp
+  #mkdir -p /opt/factorio/temp
+  #chown -R factorio:factorio /opt/factorio/temp
+  # Drop to the factorio user
+  SU_EXEC="su-exec factorio"
+fi

--- a/0.17/files/scenario.sh
+++ b/0.17/files/scenario.sh
@@ -5,40 +5,6 @@ if [ -z "$1" ]
 fi
 SCENARIO=$1
 
-set -e
+sh /initConfig.sh
 
-id
-
-mkdir -p $SAVES
-mkdir -p $CONFIG
-mkdir -p $MODS
-mkdir -p $SCENARIOS
-
-#chown -R factorio /factorio
-
-if [ ! -f $CONFIG/rconpw ]; then
-  echo $(pwgen 15 1) > $CONFIG/rconpw
-fi
-
-if [ ! -f $CONFIG/server-settings.json ]; then
-  cp /opt/factorio/data/server-settings.example.json $CONFIG/server-settings.json
-fi
-
-if [ ! -f $CONFIG/map-gen-settings.json ]; then
-  cp /opt/factorio/data/map-gen-settings.example.json $CONFIG/map-gen-settings.json
-fi
-
-if [ ! -f $CONFIG/map-settings.json ]; then
-  cp /opt/factorio/data/map-settings.example.json $CONFIG/map-settings.json
-fi
-
-
-exec /opt/factorio/bin/x64/factorio \
-  --port $PORT \
-  --start-server-load-scenario $SCENARIO \
-  --server-settings $CONFIG/server-settings.json \
-  --server-whitelist $CONFIG/server-whitelist.json \
-  --server-banlist $CONFIG/server-banlist.json \
-  --rcon-port $RCON_PORT \
-  --rcon-password "$(cat $CONFIG/rconpw)" \
-  --server-id /factorio/config/server-id.json
+sh /startFactorio.sh "start-server-load-scenario $SCENARIO"

--- a/0.17/files/scenario2map.sh
+++ b/0.17/files/scenario2map.sh
@@ -5,26 +5,7 @@ if [ -z "$1" ]
 fi
 SCENARIO=$1
 
-set -e
-
-id
-
-mkdir -p $SAVES
-mkdir -p $CONFIG
-mkdir -p $MODS
-mkdir -p $SCENARIOS
-
-if [ ! -f $CONFIG/server-settings.json ]; then
-  cp /opt/factorio/data/server-settings.example.json $CONFIG/server-settings.json
-fi
-
-if [ ! -f $CONFIG/map-gen-settings.json ]; then
-  cp /opt/factorio/data/map-gen-settings.example.json $CONFIG/map-gen-settings.json
-fi
-
-if [ ! -f $CONFIG/map-settings.json ]; then
-  cp /opt/factorio/data/map-settings.example.json $CONFIG/map-settings.json
-fi
+sh /initConfig.sh
 
 exec /opt/factorio/bin/x64/factorio \
   --scenario2map $SCENARIO

--- a/0.17/files/startFactorio.sh
+++ b/0.17/files/startFactorio.sh
@@ -1,0 +1,20 @@
+#!/bin/sh -x
+if [ -z "$1" ]
+  then
+    echo "No argument supplied"
+fi
+CMD=$1
+
+
+exec ${SU_EXEC} /opt/factorio/bin/x64/factorio \
+  --port $PORT \
+  --$CMD \
+  --server-settings $CONFIG/server-settings.json \
+  --server-banlist $CONFIG/server-banlist.json \
+  --rcon-port $RCON_PORT \
+  --server-whitelist $CONFIG/server-whitelist.json \
+  --use-server-whitelist \
+  --server-adminlist $CONFIG/server-adminlist.json \
+  --rcon-password "$(cat $CONFIG/rconpw)" \
+  --server-id /factorio/config/server-id.json \
+  "$@"

--- a/README.md
+++ b/README.md
@@ -206,6 +206,14 @@ The `server-settings.json` file may then contain the variable references like th
 	"name": "${INSTANCE_NAME}",
 	"description": "${INSTANCE_DESC}",
 
+## Provisioning of the container
+
+If you want to provide any of the configuration files, savegames or mods to the container, you can mount a folder in `/provisioning` which contains any of the following folders:
+
+* `saves` any savegame to be loaded during startup (the latest is automatically loaded)
+* `config` any configuration you want to provide (e.g. map-gen-settings.json)
+* `mods` any mods that should be started (zip files)
+* `scenarios` scenarios available on the server. This requires the "scenarios.sh" endpoint (see above)
 
 # Container Details
 


### PR DESCRIPTION
Hi again, 

i spend some time on the weekend to find a better way to centralize the generation of the config files. 

Currently both `scenario.sh` and `docker-entrypoint.sh` do very similar stuff but the `scenario.sh` is outdated and misses some of the improvements done in `docker-entrypoint.sh`.
To prevent this situation, I'd suggest to externalize the creation of the config/saves/mods folders into a script and call this from the entrypoints. So any update only needs to be done once and not in every entrypoint.

The same is valid for the start of the server, which in both cases requires the same parameters (aside from `start-server-***` which is different. Currently the `scenario.sh` does not fall back to the factorio user but still executes factorio as root. Therefor I'd also suggest to use a central script here which can be called and takes care of the execution. 

Please have a look into the code and give feedback.

Note: I also added an optional /provisioning folder, where any configs, saves or mods can be places. Those will be loaded when the server starts. This allows us to bootstrap the server without the need of any restarts (which is very handy when running e.g. on AWS or GCP where you don't want to access the container). 