### PR TITLE
Revert "Update to 0.17.12"

### DIFF
--- a/0.17/Dockerfile
+++ b/0.17/Dockerfile
@@ -9,8 +9,8 @@ ARG PGID=845
 
 ENV PORT=34197 \
     RCON_PORT=27015 \
-    VERSION=0.17.12 \
-    SHA1=5088846835438ddaffdd3244b24163fb7fb5dd06 \
+    VERSION=0.17.11 \
+    SHA1=6891054a90db4b52733582d3470de92eca58c730 \
     SAVES=/factorio/saves \
     CONFIG=/factorio/config \
     MODS=/factorio/mods \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Factorio [![](https://images.microbadger.com/badges/image/dtandersen/factorio.svg)](https://microbadger.com/images/dtandersen/factorio "Get your own image badge on microbadger.com") [![Docker Pulls](https://img.shields.io/docker/pulls/dtandersen/factorio.svg)](https://hub.docker.com/r/dtandersen/factorio/) [![Docker Stars](https://img.shields.io/docker/stars/dtandersen/factorio.svg)](https://hub.docker.com/r/dtandersen/factorio/)
 
-* `0.17.12`, `0.17`, `latest` [(0.17/Dockerfile)](https://github.com/dtandersen/docker_factorio_server/blob/master/0.17/Dockerfile)
+* `0.17.11`, `0.17`, `latest` [(0.17/Dockerfile)](https://github.com/dtandersen/docker_factorio_server/blob/master/0.17/Dockerfile)
 * `0.16.51`, `0.16`, `stable` [(0.16/Dockerfile)](https://github.com/dtandersen/docker_factorio_server/blob/master/0.16/Dockerfile)
 * `0.15.40`, `0.15` [(0.15/Dockerfile)](https://github.com/dtandersen/docker_factorio_server/blob/master/0.15/Dockerfile)
 * `0.14.23`, `0.14` [(0.14/Dockerfile)](https://github.com/dtandersen/docker_factorio_server/blob/master/0.14/Dockerfile)


### PR DESCRIPTION
Reverts dtandersen/docker_factorio_server#217:

0.17.12 is not a functional headless server release due to 
https://forums.factorio.com/viewtopic.php?f=7&t=67735

We should stay with 0.17.11 and upgrade to 0.17.13 asav.