### PR TITLE
Fix conflicting group IDs

### DIFF
--- a/0.17/files/docker-entrypoint.sh
+++ b/0.17/files/docker-entrypoint.sh
@@ -36,8 +36,8 @@ fi
 
 if [ "$(id -u)" = '0' ]; then
   # Update the User and Group ID based on the PUID/PGID variables
-  usermod -u $PUID factorio
-  groupmod -g $PGID factorio
+  usermod -o -u $PUID factorio
+  groupmod -o -g $PGID factorio
   # Take ownership of factorio data if running as root
   chown -R factorio:factorio $FACTORIO_VOL
   # Make sure we own temp


### PR DESCRIPTION
Add the `-o` switch to usermod and groupmod in order to allow non-unique IDs to be specified. 
This is in relation to issue #231